### PR TITLE
chore(vscode): updated vscode recommended settings

### DIFF
--- a/.vscode/recommended-settings.json
+++ b/.vscode/recommended-settings.json
@@ -20,6 +20,9 @@
   "clang-format.language.objective-cpp.enable": false,
   "clang-format.language.typescript.enable": false,
   "clang-format.style": "Google",
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
   "editor.codeActionsOnSave": {
     "source.organizeImports": false,
     "source.fixAll.eslint": true,


### PR DESCRIPTION
default formatter for typescript should be eslint