### PR TITLE
docs(diagrams): add command that exports mmd as a png file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 /android/build/
 /android/app/build/
 /android/capacitor-cordova-android-plugins/build/
+# diagrams are saved by default to the directory where input files reside
+tools/diagrams/*.*
+!tools/diagrams/*.mmd
+
 
 # firebase
 .firebase
@@ -59,3 +63,4 @@ Thumbs.db
 # Local Files
 *.keystore
 /tools/shell/vars.sh
+

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "firebase:deploy:localhost:documentation": "yarn build:documentation:prod && bash tools/shell/firebase-deploy.sh localhost documentation",
     "generate:changelog": "bash tools/shell/changelog.sh all",
     "generate:client-gql": "ng run api-interface:generate-client-definitions",
+    "generate:diagrams": "mkdir dist/diagrams || true && yarn workspace:mmdc -i tools/diagrams/branching.mmd -o dist/diagrams/branching.png && yarn workspace:mmdc -i tools/diagrams/master-on-push-pipeline.mmd -o dist/diagrams/master-on-push-pipeline.png && yarn workspace:mmdc -i tools/diagrams/pr-validation-pipeline.mmd -o dist/diagrams/pr-validation-pipeline.png",
     "generate:env:documentation": "bash tools/shell/set-documentation-env.sh",
     "generate:proto:all": "npx npm-run-all -s generate:protobufjs generate:protoc",
     "generate:protobufjs": "bash tools/shell/generate-proto.sh protobufjs",


### PR DESCRIPTION
Diagrams should be used to describe processes in the monorepo.
