### PR TITLE
docs(github): replace community support link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
-  - name: GitHub Community Support
-    url: https://github.community/
+  - name: Community Support
+    url: https://github.com/rfprod/nx-ng-starter/discussions
     about: Please ask and answer questions here.
   - name: GitHub Security Bug Bounty
     url: https://bounty.github.com/


### PR DESCRIPTION
- [x] use nx-ng-starter discussions link for the community support option;