### PR TITLE
ci(trunk): fix trunk workflow

### DIFF
--- a/.github/workflows/trunk.yml
+++ b/.github/workflows/trunk.yml
@@ -20,6 +20,7 @@ jobs:
 
     outputs:
       changes: ${{ steps.check-changes.outputs.changes }}
+      deploy: ${{ steps.check-changes.outputs.deploy }}
       origin: ${{ steps.check-origin.outputs.origin }}
 
     steps:


### PR DESCRIPTION
- [x] map a missing output in the 'checks' job;