### PR TITLE
refactor(tests): refactor unit tests

### DIFF
--- a/apps/client/src/app/components/root.component.spec.ts
+++ b/apps/client/src/app/components/root.component.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { Meta, Title } from '@angular/platform-browser';
 import { AppServiceWorkerService } from '@app/client-service-worker';
 import { testingEnvironment } from '@app/client-testing-unit';
@@ -43,19 +43,16 @@ describe('AppRootComponent', () => {
   let meta: Meta;
   let updateTagSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppRootComponent);
-        component = fixture.componentInstance;
-        title = TestBed.inject(Title);
-        setTitleSpy = jest.spyOn(title, 'setTitle');
-        meta = TestBed.inject(Meta);
-        updateTagSpy = jest.spyOn(meta, 'updateTag');
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppRootComponent);
+    component = fixture.componentInstance;
+    title = TestBed.inject(Title);
+    setTitleSpy = jest.spyOn(title, 'setTitle');
+    meta = TestBed.inject(Meta);
+    updateTagSpy = jest.spyOn(meta, 'updateTag');
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/apps/documentation/src/app/componenets/md-reference-tree/md-reference-tree.component.spec.ts
+++ b/apps/documentation/src/app/componenets/md-reference-tree/md-reference-tree.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppMaterialModule } from '@app/client-material';
@@ -46,19 +46,14 @@ describe('AppDocMarkdownReferenceTreeComponent', () => {
   let store: Store<IMdFilesState>;
   let storeDispatchSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDocMarkdownReferenceTreeComponent);
-        component = fixture.debugElement.componentInstance;
-
-        store = TestBed.inject(Store);
-        storeDispatchSpy = jest.spyOn(store, 'dispatch');
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDocMarkdownReferenceTreeComponent);
+    component = fixture.debugElement.componentInstance;
+    store = TestBed.inject(Store);
+    storeDispatchSpy = jest.spyOn(store, 'dispatch');
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/apps/documentation/src/app/componenets/md-reference/md-reference.component.spec.ts
+++ b/apps/documentation/src/app/componenets/md-reference/md-reference.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppMaterialModule } from '@app/client-material';
@@ -42,16 +42,12 @@ describe('AppDocMarkdownReferenceComponent', () => {
   let fixture: ComponentFixture<AppDocMarkdownReferenceComponent>;
   let component: AppDocMarkdownReferenceComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDocMarkdownReferenceComponent);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDocMarkdownReferenceComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-chatbot/src/lib/components/chatbot-root/chatbot-root.component.spec.ts
+++ b/libs/client-chatbot/src/lib/components/chatbot-root/chatbot-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 import { AppElizaModule } from '@app/client-util-eliza';
 
@@ -14,16 +14,12 @@ describe('AppChatbotRootComponent', () => {
   let fixture: ComponentFixture<AppChatbotRootComponent>;
   let component: AppChatbotRootComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppChatbotRootComponent);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppChatbotRootComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-chatbot/src/lib/components/chatbot-widget-root/chatbot-widget-root.component.spec.ts
+++ b/libs/client-chatbot/src/lib/components/chatbot-widget-root/chatbot-widget-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 import { AppElizaModule } from '@app/client-util-eliza';
 
@@ -14,16 +14,12 @@ describe('AppChatbotWidgetRootComponent', () => {
   let fixture: ComponentFixture<AppChatbotWidgetRootComponent>;
   let component: AppChatbotWidgetRootComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppChatbotWidgetRootComponent);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppChatbotWidgetRootComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-core-components/src/lib/components/content/content.component.spec.ts
+++ b/libs/client-core-components/src/lib/components/content/content.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppSidebarStoreModule, sidebarActions } from '@app/client-store-sidebar';
@@ -31,23 +31,17 @@ describe('AppContentComponent', () => {
   };
   let router: Router;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppContentComponent);
-        component = fixture.debugElement.componentInstance;
-
-        store = TestBed.inject(Store);
-        storeSpy = {
-          dispatch: jest.spyOn(store, 'dispatch').mockImplementation((action: unknown) => of(null)),
-        };
-
-        router = TestBed.inject(Router);
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppContentComponent);
+    component = fixture.debugElement.componentInstance;
+    store = TestBed.inject(Store);
+    storeSpy = {
+      dispatch: jest.spyOn(store, 'dispatch').mockImplementation((action: unknown) => of(null)),
+    };
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();
@@ -58,10 +52,10 @@ describe('AppContentComponent', () => {
     expect(storeSpy.dispatch).toHaveBeenCalledWith(sidebarActions.close({ payload: { navigate: true } }));
   });
 
-  it('sidebarOpenHandler should call store dispatch', waitForAsync(() => {
+  it('sidebarOpenHandler should call store dispatch', () => {
     component.sidebarOpenHandler();
     expect(storeSpy.dispatch).toHaveBeenCalledWith(sidebarActions.open({ payload: { navigate: true } }));
-  }));
+  });
 
   it('should scroll content on router events', async () => {
     expect(component.content).toBeDefined();

--- a/libs/client-core-components/src/lib/components/history-navigator/history-navigator.component.spec.ts
+++ b/libs/client-core-components/src/lib/components/history-navigator/history-navigator.component.spec.ts
@@ -1,5 +1,5 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 
 import { AppHistoryNavigatorComponent } from './history-navigator.component';
@@ -17,21 +17,16 @@ describe('AppHistoryNavigatorComponent', () => {
     forward: jest.SpyInstance;
   };
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppHistoryNavigatorComponent);
-        component = fixture.debugElement.componentInstance;
-
-        spy = {
-          back: jest.spyOn(component.nagivateBack, 'emit'),
-          forward: jest.spyOn(component.nagivateForward, 'emit'),
-        };
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppHistoryNavigatorComponent);
+    component = fixture.debugElement.componentInstance;
+    spy = {
+      back: jest.spyOn(component.nagivateBack, 'emit'),
+      forward: jest.spyOn(component.nagivateForward, 'emit'),
+    };
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-core-components/src/lib/components/navbar/navbar.component.spec.ts
+++ b/libs/client-core-components/src/lib/components/navbar/navbar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 import { of } from 'rxjs';
@@ -25,19 +25,14 @@ describe('AppNavbarComponent', () => {
   let router: Router;
   let routerIsActiveSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppNavbarComponent);
-        component = fixture.debugElement.componentInstance;
-
-        router = TestBed.inject(Router);
-        routerIsActiveSpy = jest.spyOn(router, 'isActive');
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppNavbarComponent);
+    component = fixture.debugElement.componentInstance;
+    router = TestBed.inject(Router);
+    routerIsActiveSpy = jest.spyOn(router, 'isActive');
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-core-components/src/lib/components/theme-toggle/theme-toggle.component.spec.ts
+++ b/libs/client-core-components/src/lib/components/theme-toggle/theme-toggle.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 
@@ -13,16 +13,12 @@ describe('AppThemeToggleComponent', () => {
   let fixture: ComponentFixture<AppThemeToggleComponent>;
   let component: AppThemeToggleComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppThemeToggleComponent);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppThemeToggleComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-core-components/src/lib/components/toolbar/toolbar.component.spec.ts
+++ b/libs/client-core-components/src/lib/components/toolbar/toolbar.component.spec.ts
@@ -1,5 +1,5 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { newTestBedMetadata } from '@app/client-testing-unit';
@@ -16,16 +16,12 @@ describe('AppToolbarComponent', () => {
   let fixture: ComponentFixture<AppToolbarComponent>;
   let component: AppToolbarComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppToolbarComponent);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppToolbarComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-core-components/src/lib/components/tooltip/tooltip.directive.spec.ts
+++ b/libs/client-core-components/src/lib/components/tooltip/tooltip.directive.spec.ts
@@ -1,6 +1,6 @@
 import { OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
 import { DebugElement } from '@angular/core';
-import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { AppMaterialModule } from '@app/client-material';
 import { AppTestingComponent } from '@app/client-testing-unit';
@@ -12,8 +12,8 @@ describe('AppTooltipDirective', () => {
   let debugElement: DebugElement;
   let directive: AppTooltipDirective;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [AppMaterialModule.forRoot()],
       declarations: [AppTestingComponent, AppTooltipDirective],
       providers: [
@@ -22,17 +22,12 @@ describe('AppTooltipDirective', () => {
           useFactory: () => new OverlayConfig(),
         },
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppTestingComponent);
-        debugElement = fixture.debugElement.query(By.directive(AppTooltipDirective));
-
-        directive = debugElement.injector.get(AppTooltipDirective);
-
-        fixture.detectChanges();
-      });
-  }));
+    }).compileComponents();
+    fixture = TestBed.createComponent(AppTestingComponent);
+    debugElement = fixture.debugElement.query(By.directive(AppTooltipDirective));
+    directive = debugElement.injector.get(AppTooltipDirective);
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(directive).toBeDefined();

--- a/libs/client-d3-charts/jest.config.ts
+++ b/libs/client-d3-charts/jest.config.ts
@@ -7,10 +7,10 @@ const config: Config.InitialOptions = {
   coverageThreshold: {
     // TODO: bump coverage thresholds
     global: {
-      branches: 8,
-      functions: 28,
-      lines: 27,
-      statements: 30,
+      branches: 3,
+      functions: 18,
+      lines: 23,
+      statements: 25,
     },
   },
   displayName: 'client-d3-charts',

--- a/libs/client-d3-charts/src/lib/components/bar-chart/bar-chart.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/bar-chart/bar-chart.component.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -24,16 +24,12 @@ describe('AppBarChartComponent', () => {
   let fixture: ComponentFixture<AppBarChartComponent>;
   let component: AppBarChartComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppBarChartComponent);
-        component = fixture.debugElement.componentInstance;
-
-        // fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppBarChartComponent);
+    component = fixture.debugElement.componentInstance;
+    // fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-d3-charts/src/lib/components/chart-examples/chart-examples.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/chart-examples/chart-examples.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { AppChartExamplesComponent } from './chart-examples.component';
 
@@ -10,15 +10,12 @@ describe('AppGlobalProgressBarComponent', () => {
   let fixture: ComponentFixture<AppChartExamplesComponent>;
   let component: AppChartExamplesComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppChartExamplesComponent);
-        component = fixture.debugElement.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppChartExamplesComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-d3-charts/src/lib/components/force-directed-chart/force-directed-chart.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/force-directed-chart/force-directed-chart.component.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -24,16 +24,12 @@ describe('AppForceDirectedChartComponent', () => {
   let fixture: ComponentFixture<AppForceDirectedChartComponent>;
   let component: AppForceDirectedChartComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppForceDirectedChartComponent);
-        component = fixture.debugElement.componentInstance;
-
-        // fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppForceDirectedChartComponent);
+    component = fixture.debugElement.componentInstance;
+    // fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-d3-charts/src/lib/components/line-chart/line-chart.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/line-chart/line-chart.component.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -24,16 +24,12 @@ describe('AppLineChartComponent', () => {
   let fixture: ComponentFixture<AppLineChartComponent>;
   let component: AppLineChartComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppLineChartComponent);
-        component = fixture.debugElement.componentInstance;
-
-        // fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppLineChartComponent);
+    component = fixture.debugElement.componentInstance;
+    // fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-d3-charts/src/lib/components/pie-chart/pie-chart.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/pie-chart/pie-chart.component.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -24,16 +24,13 @@ describe('AppPieChartComponent', () => {
   let fixture: ComponentFixture<AppPieChartComponent>;
   let component: AppPieChartComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppPieChartComponent);
-        component = fixture.debugElement.componentInstance;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppPieChartComponent);
+    component = fixture.debugElement.componentInstance;
 
-        // fixture.detectChanges();
-      });
-  }));
+    // fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-d3-charts/src/lib/components/radar-chart/radar-chart.component.spec.ts
+++ b/libs/client-d3-charts/src/lib/components/radar-chart/radar-chart.component.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BrowserDynamicTestingModule } from '@angular/platform-browser-dynamic/testing';
 
@@ -24,16 +24,12 @@ describe('AppRadarChartComponent', () => {
   let fixture: ComponentFixture<AppRadarChartComponent>;
   let component: AppRadarChartComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppRadarChartComponent);
-        component = fixture.debugElement.componentInstance;
-
-        // fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppRadarChartComponent);
+    component = fixture.debugElement.componentInstance;
+    // fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-dashboards/src/lib/components/dashboards/dashboards.component.spec.ts
+++ b/libs/client-dashboards/src/lib/components/dashboards/dashboards.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 
 import { AppDashboardsComponent } from './dashboards.component';
@@ -12,15 +12,12 @@ describe('AppDashboardsComponent', () => {
   });
   const testBedConfig: TestModuleMetadata = getTestBedConfig(testBedMetadata);
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDashboardsComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDashboardsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/libs/client-dashboards/src/lib/components/table/table.component.spec.ts
+++ b/libs/client-dashboards/src/lib/components/table/table.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 
 import { AppTableComponent } from './table.component';
@@ -12,15 +12,12 @@ describe('AppTableComponent', () => {
   });
   const testBedConfig: TestModuleMetadata = getTestBedConfig(testBedMetadata);
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppTableComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/libs/client-diagnostics/src/lib/components/home/diagnostics-home.component.spec.ts
+++ b/libs/client-diagnostics/src/lib/components/home/diagnostics-home.component.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
@@ -28,16 +28,12 @@ describe('AppDiagnosticsHomeComponent', () => {
   let fixture: ComponentFixture<AppDiagnosticsHomeComponent>;
   let component: AppDiagnosticsHomeComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDiagnosticsHomeComponent);
-        component = fixture.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDiagnosticsHomeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-diagnostics/src/lib/components/home/page/diagnostics-home-page.component.spec.ts
+++ b/libs/client-diagnostics/src/lib/components/home/page/diagnostics-home-page.component.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { newTestBedMetadata } from '@app/client-testing-unit';
@@ -16,16 +16,12 @@ describe('AppDiagnosticsHomePage', () => {
   let fixture: ComponentFixture<AppDiagnosticsHomePage>;
   let component: AppDiagnosticsHomePage;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDiagnosticsHomePage);
-        component = fixture.debugElement.componentInstance;
-
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDiagnosticsHomePage);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-diagnostics/src/lib/components/index/diagnostics-index.component.spec.ts
+++ b/libs/client-diagnostics/src/lib/components/index/diagnostics-index.component.spec.ts
@@ -1,5 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { diagnosticsActions } from '@app/client-store-diagnostics';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 import { Store } from '@ngrx/store';
@@ -25,17 +25,14 @@ describe('AppDiagnosticsIndexComponent', () => {
   let store: Store;
   let storeDispatchSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        storeDispatchSpy = jest.spyOn(store, 'dispatch');
-        fixture = TestBed.createComponent(AppDiagnosticsIndexComponent);
-        component = fixture.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    storeDispatchSpy = jest.spyOn(store, 'dispatch');
+    fixture = TestBed.createComponent(AppDiagnosticsIndexComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-diagnostics/src/lib/components/info/diagnostics-info.component.spec.ts
+++ b/libs/client-diagnostics/src/lib/components/info/diagnostics-info.component.spec.ts
@@ -1,11 +1,11 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { httpApiSelectors, IHttpApiState } from '@app/client-store-http-api';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 import { Store } from '@ngrx/store';
-import { combineLatest, first, of, tap } from 'rxjs';
+import { first, lastValueFrom, of } from 'rxjs';
 
 import { AppDiagnosticsInfoComponent } from './diagnostics-info.component';
 
@@ -29,29 +29,22 @@ describe('AppDiagnosticsInfoComponent', () => {
   let component: AppDiagnosticsInfoComponent;
   let store: Store<IHttpApiState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDiagnosticsInfoComponent);
-        component = fixture.componentInstance;
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDiagnosticsInfoComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();
   });
 
-  it('state should return the whole ping state', waitForAsync(() => {
-    void combineLatest([component.ping$.pipe(first()), store.select(httpApiSelectors.ping).pipe(first())])
-      .pipe(
-        tap(([ping, pingState]) => {
-          expect(ping).toEqual(pingState);
-        }),
-      )
-      .subscribe();
-  }));
+  it('state should return the whole ping state', async () => {
+    const ping = await lastValueFrom(component.ping$.pipe(first()));
+    const pingState = await lastValueFrom(store.select(httpApiSelectors.ping).pipe(first()));
+    expect(ping).toEqual(pingState);
+  });
 
   it('should dispatch one event on init', () => {
     const spy = jest.spyOn(store, 'dispatch');

--- a/libs/client-diagnostics/src/lib/components/info/page/diagnostics-info-page.component.spec.ts
+++ b/libs/client-diagnostics/src/lib/components/info/page/diagnostics-info-page.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { newTestBedMetadata } from '@app/client-testing-unit';
@@ -14,14 +14,11 @@ describe('AppDiagnosticsInfoPage', () => {
   let fixture: ComponentFixture<AppDiagnosticsInfoPage>;
   let component: AppDiagnosticsInfoPage;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppDiagnosticsInfoPage);
-        component = fixture.componentInstance;
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppDiagnosticsInfoPage);
+    component = fixture.componentInstance;
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-directives/src/lib/autoscroll/autoscroll.directive.spec.ts
+++ b/libs/client-directives/src/lib/autoscroll/autoscroll.directive.spec.ts
@@ -12,18 +12,15 @@ describe('AppAutoscrollDirective', () => {
   let debugElement: DebugElement;
   let directive: AppAutoscrollDirective;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       declarations: [AppTestingComponent, AppAutoscrollDirective],
-    })
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppTestingComponent);
-        debugElement = fixture.debugElement.query(By.directive(AppAutoscrollDirective));
-        directive = debugElement.injector.get(AppAutoscrollDirective);
-        // fixture.detectChanges();
-      });
-  }));
+    }).compileComponents();
+    fixture = TestBed.createComponent(AppTestingComponent);
+    debugElement = fixture.debugElement.query(By.directive(AppAutoscrollDirective));
+    directive = debugElement.injector.get(AppAutoscrollDirective);
+    // fixture.detectChanges();
+  });
 
   it('should compile successfully', () => {
     expect(directive).toBeDefined();

--- a/libs/client-elements/src/lib/services/elements.service.spec.ts
+++ b/libs/client-elements/src/lib/services/elements.service.spec.ts
@@ -1,5 +1,5 @@
 import { Injector } from '@angular/core';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { newTestBedMetadata } from '@app/client-testing-unit';
 import { WINDOW, windowProvider } from '@app/client-util';
 
@@ -14,14 +14,11 @@ describe('AppElementsService', () => {
 
   let win: Window;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppElementsService);
-        win = TestBed.inject(WINDOW);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppElementsService);
+    win = TestBed.inject(WINDOW);
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();

--- a/libs/client-gql/src/lib/services/gql/gql.service.spec.ts
+++ b/libs/client-gql/src/lib/services/gql/gql.service.spec.ts
@@ -34,15 +34,12 @@ describe('AppClientGqlService', () => {
   let apollo: Apollo;
   const clientName: TGqlClient = 'graphql';
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppGqlService);
-        handlers = TestBed.inject(AppHttpHandlersService);
-        apollo = TestBed.inject(Apollo);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppGqlService);
+    handlers = TestBed.inject(AppHttpHandlersService);
+    apollo = TestBed.inject(Apollo);
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();

--- a/libs/client-material/src/lib/configs/hammerjs-gesture/hammerjs-gesture.config.spec.ts
+++ b/libs/client-material/src/lib/configs/hammerjs-gesture/hammerjs-gesture.config.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { HammerGestureConfig } from '@angular/platform-browser';
 
 import { AppHammerGestureConfig } from './hammerjs-gesture.config';
@@ -10,13 +10,10 @@ describe('AppHammerGestureConfig', () => {
 
   let hammerGestureConfig: HammerGestureConfig;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        hammerGestureConfig = TestBed.inject(AppHammerGestureConfig);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    hammerGestureConfig = TestBed.inject(AppHammerGestureConfig);
+  });
 
   it('should have expected properties', () => {
     const expectedOverrides = {

--- a/libs/client-material/src/lib/providers/material-module.providers.spec.ts
+++ b/libs/client-material/src/lib/providers/material-module.providers.spec.ts
@@ -1,5 +1,5 @@
 import { OverlayConfig } from '@angular/cdk/overlay';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MAT_DATE_FORMATS, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MatIconRegistry } from '@angular/material/icon';
 import { MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY, MatMomentDateAdapterOptions } from '@angular/material-moment-adapter';
@@ -21,18 +21,15 @@ describe('client-material-module-proviers', () => {
   let hammerGestureConfig: HammerGestureConfig;
   let overlayConfig: OverlayConfig;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        matIconsRegistry = TestBed.inject(MatIconRegistry);
-        matDateLocale = TestBed.inject(MAT_DATE_LOCALE) as string;
-        matMomentDateAdapter = TestBed.inject(MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY);
-        matDateFormats = TestBed.inject(MAT_DATE_FORMATS);
-        hammerGestureConfig = TestBed.inject(HAMMER_GESTURE_CONFIG);
-        overlayConfig = TestBed.inject(OverlayConfig);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    matIconsRegistry = TestBed.inject(MatIconRegistry);
+    matDateLocale = TestBed.inject(MAT_DATE_LOCALE) as string;
+    matMomentDateAdapter = TestBed.inject(MAT_MOMENT_DATE_ADAPTER_OPTIONS_FACTORY);
+    matDateFormats = TestBed.inject(MAT_DATE_FORMATS);
+    hammerGestureConfig = TestBed.inject(HAMMER_GESTURE_CONFIG);
+    overlayConfig = TestBed.inject(OverlayConfig);
+  });
 
   it('appMaterialModuleProviders should provide expected providers', () => {
     expect(matIconsRegistry).toBeDefined();

--- a/libs/client-pwa-offline/src/lib/components/pwa-offline/pwa-offline.component.spec.ts
+++ b/libs/client-pwa-offline/src/lib/components/pwa-offline/pwa-offline.component.spec.ts
@@ -1,21 +1,23 @@
 import { CommonModule, Location } from '@angular/common';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 
 import { AppPwaOfflineComponent } from './pwa-offline.component';
 
 describe('AppPwaOfflineComponent', () => {
+  const testBedMetadata: TestModuleMetadata = {
+    imports: [CommonModule, MatIconModule, MatButtonModule],
+    declarations: [AppPwaOfflineComponent],
+    providers: [Location],
+  };
+
   let component: AppPwaOfflineComponent;
   let fixture: ComponentFixture<AppPwaOfflineComponent>;
   let location: Location;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [CommonModule, MatIconModule, MatButtonModule],
-      declarations: [AppPwaOfflineComponent],
-      providers: [Location],
-    }).compileComponents();
+    await TestBed.configureTestingModule(testBedMetadata).compileComponents();
 
     location = TestBed.inject(Location);
     fixture = TestBed.createComponent(AppPwaOfflineComponent);

--- a/libs/client-service-worker/src/lib/services/service-worker.service.spec.ts
+++ b/libs/client-service-worker/src/lib/services/service-worker.service.spec.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { ApplicationRef } from '@angular/core';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate, VersionEvent } from '@angular/service-worker';
 import { of } from 'rxjs';
@@ -41,13 +41,10 @@ describe('AppServiceWorkerService', () => {
     ],
   };
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppServiceWorkerService);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppServiceWorkerService);
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();

--- a/libs/client-sidebar/src/lib/components/sidebar-root/sidebar-root.component.spec.ts
+++ b/libs/client-sidebar/src/lib/components/sidebar-root/sidebar-root.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppHttpProgressStoreModule } from '@app/client-store-http-progress';
@@ -37,20 +37,17 @@ describe('AppSidebarRootComponent', () => {
   let router: Router;
   let routerNavigateSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppSidebarRootComponent);
-        component = fixture.componentInstance;
-        store = TestBed.inject(Store);
-        storeDispatchSpy = jest.spyOn(store, 'dispatch');
-        sidebarCloseHandlerSpy = jest.spyOn(component, 'sidebarCloseHandler');
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate');
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppSidebarRootComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(Store);
+    storeDispatchSpy = jest.spyOn(store, 'dispatch');
+    sidebarCloseHandlerSpy = jest.spyOn(component, 'sidebarCloseHandler');
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate');
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-store-chatbot/src/lib/chatbot.effects.spec.ts
+++ b/libs/client-store-chatbot/src/lib/chatbot.effects.spec.ts
@@ -23,15 +23,12 @@ describe('AppChatbotEffects', () => {
   let router: Router;
   let routerNavigateSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
+  });
 
   it('should call router.navigate when the open action is dispatched', waitForAsync(() => {
     store.dispatch(chatbotActions.open());

--- a/libs/client-store-chatbot/src/lib/chatbot.reducer.spec.ts
+++ b/libs/client-store-chatbot/src/lib/chatbot.reducer.spec.ts
@@ -1,7 +1,7 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 import { Store, StoreModule } from '@ngrx/store';
-import { first, switchMap, tap } from 'rxjs';
+import { first, lastValueFrom } from 'rxjs';
 
 import { chatbotActions } from './chatbot.actions';
 import { chatbotReducerConfig, IChatbotState, IChatbotStateModel } from './chatbot.interface';
@@ -18,14 +18,11 @@ describe('AppChatbotReducer', () => {
   let reducer: AppChatbotReducer;
   let store: Store<IChatbotState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppChatbotReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppChatbotReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();
@@ -37,21 +34,13 @@ describe('AppChatbotReducer', () => {
     expect(initialState).toEqual(expectation);
   });
 
-  it('should process the open/close action correctly', waitForAsync(() => {
+  it('should process the open/close action correctly', async () => {
     store.dispatch(chatbotActions.open());
-    void store
-      .select(chatbotSelectors.chatbotOpen)
-      .pipe(
-        first(),
-        tap(chatbotOpen => {
-          expect(chatbotOpen).toBeTruthy();
-          store.dispatch(chatbotActions.close());
-        }),
-        switchMap(() => store.select(chatbotSelectors.chatbotOpen)),
-        tap(chatbotOpen => {
-          expect(chatbotOpen).toBeFalsy();
-        }),
-      )
-      .subscribe();
-  }));
+    let chatbotOpen = await lastValueFrom(store.select(chatbotSelectors.chatbotOpen).pipe(first()));
+    expect(chatbotOpen).toBeTruthy();
+
+    store.dispatch(chatbotActions.close());
+    chatbotOpen = await lastValueFrom(store.select(chatbotSelectors.chatbotOpen).pipe(first()));
+    expect(chatbotOpen).toBeFalsy();
+  });
 });

--- a/libs/client-store-diagnostics/src/lib/diagnostics.effects.spec.ts
+++ b/libs/client-store-diagnostics/src/lib/diagnostics.effects.spec.ts
@@ -34,14 +34,11 @@ describe('AppDiagnosticsEffects', () => {
   let store: Store<IDiagnosticsState>;
   let api: AppWebsocketApiService;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        api = TestBed.inject(AppWebsocketApiService);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    api = TestBed.inject(AppWebsocketApiService);
+  });
 
   it('should call api service connect method when the connect action is dispatched, payload #1', waitForAsync(() => {
     const connectSpy = jest.spyOn(api, 'connect');

--- a/libs/client-store-diagnostics/src/lib/diagnostics.reducer.spec.ts
+++ b/libs/client-store-diagnostics/src/lib/diagnostics.reducer.spec.ts
@@ -18,14 +18,11 @@ describe('AppDiagnosticsReducer', () => {
   let reducer: AppDiagnosticsReducer;
   let store: Store<IDiagnosticsState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppDiagnosticsReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppDiagnosticsReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();

--- a/libs/client-store-diagnostics/src/lib/services/static-data/static-data-api.service.spec.ts
+++ b/libs/client-store-diagnostics/src/lib/services/static-data/static-data-api.service.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { AppHttpHandlersService } from '@app/client-store-http-progress';
 import { flushHttpRequests, getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
-import { of, tap } from 'rxjs';
+import { lastValueFrom, of } from 'rxjs';
 
 import { AppStaticDataService } from './static-data-api.service';
 
@@ -35,36 +35,27 @@ describe('AppStaticDataService', () => {
 
   let httpController: HttpTestingController;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        httpController = TestBed.inject(HttpTestingController);
-        service = TestBed.inject(AppStaticDataService);
-        httpHandlers = TestBed.inject(AppHttpHandlersService);
-        httpHandlersSpy = {
-          getEndpoint: jest.spyOn(httpHandlers, 'getEndpoint'),
-          pipeHttpResponse: jest.spyOn(httpHandlers, 'pipeHttpResponse'),
-        };
-        httpClient = TestBed.inject(HttpClient);
-        httpClientGetSpy = jest.spyOn(httpClient, 'get');
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    httpController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AppStaticDataService);
+    httpHandlers = TestBed.inject(AppHttpHandlersService);
+    httpHandlersSpy = {
+      getEndpoint: jest.spyOn(httpHandlers, 'getEndpoint'),
+      pipeHttpResponse: jest.spyOn(httpHandlers, 'pipeHttpResponse'),
+    };
+    httpClient = TestBed.inject(HttpClient);
+    httpClientGetSpy = jest.spyOn(httpClient, 'get');
+  });
 
   afterEach(() => {
     flushHttpRequests(httpController, true);
   });
 
-  it('the ping method should work as expected', waitForAsync(() => {
-    void service
-      .staticData()
-      .pipe(
-        tap(() => {
-          expect(httpHandlersSpy.getEndpoint).toHaveBeenCalledWith('diagnostics/static');
-          expect(httpClientGetSpy).toHaveBeenCalledWith('http://diagnostics/static');
-          expect(httpHandlersSpy.pipeHttpResponse).toHaveBeenCalledTimes(1);
-        }),
-      )
-      .subscribe();
-  }));
+  it('the ping method should work as expected', async () => {
+    await lastValueFrom(service.staticData());
+    expect(httpHandlersSpy.getEndpoint).toHaveBeenCalledWith('diagnostics/static');
+    expect(httpClientGetSpy).toHaveBeenCalledWith('http://diagnostics/static');
+    expect(httpHandlersSpy.pipeHttpResponse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libs/client-store-diagnostics/src/lib/services/websocket/websocket-api.service.spec.ts
+++ b/libs/client-store-diagnostics/src/lib/services/websocket/websocket-api.service.spec.ts
@@ -27,15 +27,12 @@ describe('AppWebsocketApiService correct connection', () => {
 
   let httpController: HttpTestingController;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        httpController = TestBed.inject(HttpTestingController);
-        service = TestBed.inject(AppWebsocketApiService);
-        wsConfig = TestBed.inject(WS_CONFIG);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    httpController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AppWebsocketApiService);
+    wsConfig = TestBed.inject(WS_CONFIG);
+  });
 
   afterEach(() => {
     flushHttpRequests(httpController, true);
@@ -101,15 +98,12 @@ describe('AppWebsocketApiService incorrect connection', () => {
 
   let httpController: HttpTestingController;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        httpController = TestBed.inject(HttpTestingController);
-        service = TestBed.inject(AppWebsocketApiService);
-        wsConfig = TestBed.inject(WS_CONFIG);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    httpController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AppWebsocketApiService);
+    wsConfig = TestBed.inject(WS_CONFIG);
+  });
 
   afterEach(() => {
     flushHttpRequests(httpController, true);

--- a/libs/client-store-feature-access/src/lib/directives/feature-flag/feature-flag.directive.spec.ts
+++ b/libs/client-store-feature-access/src/lib/directives/feature-flag/feature-flag.directive.spec.ts
@@ -36,8 +36,8 @@ describe('AppFeatureFlagDirective', () => {
 
   let store: Store;
 
-  beforeEach(() => {
-    void TestBed.configureTestingModule(testBedConfig);
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
 
     fixture = TestBed.createComponent(AppFeatureFlagTestComponent);
     component = fixture.componentInstance;

--- a/libs/client-store-http-api/src/lib/http-api.effects.spec.ts
+++ b/libs/client-store-http-api/src/lib/http-api.effects.spec.ts
@@ -32,14 +32,11 @@ describe('AppHttpApiEffects', () => {
   let store: Store<IHttpApiState>;
   let service: AppHttpApiService;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        service = TestBed.inject(AppHttpApiService);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    service = TestBed.inject(AppHttpApiService);
+  });
 
   it('should call http api service when the ping action is dispatched', waitForAsync(() => {
     const response: IPingResponse = { message: 'test' };

--- a/libs/client-store-http-api/src/lib/http-api.reducer.spec.ts
+++ b/libs/client-store-http-api/src/lib/http-api.reducer.spec.ts
@@ -18,14 +18,11 @@ describe('AppHttpApiReducer', () => {
   let reducer: AppHttpApiReducer;
   let store: Store<IHttpApiState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppHttpApiReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppHttpApiReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();

--- a/libs/client-store-http-api/src/lib/services/http-api/http-api.service.spec.ts
+++ b/libs/client-store-http-api/src/lib/services/http-api/http-api.service.spec.ts
@@ -1,9 +1,9 @@
 import { HttpClient } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { AppHttpHandlersService } from '@app/client-store-http-progress';
 import { flushHttpRequests, getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
-import { of, tap } from 'rxjs';
+import { lastValueFrom, of } from 'rxjs';
 
 import { AppHttpApiService } from './http-api.service';
 
@@ -40,36 +40,27 @@ describe('AppHttpApiService', () => {
 
   let httpController: HttpTestingController;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        httpController = TestBed.inject(HttpTestingController);
-        service = TestBed.inject(AppHttpApiService);
-        httpHandlers = TestBed.inject(AppHttpHandlersService);
-        httpHandlersSpy = {
-          getEndpoint: jest.spyOn(httpHandlers, 'getEndpoint'),
-          pipeHttpResponse: jest.spyOn(httpHandlers, 'pipeHttpResponse'),
-        };
-        httpClient = TestBed.inject(HttpClient);
-        httpClientGetSpy = jest.spyOn(httpClient, 'get');
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    httpController = TestBed.inject(HttpTestingController);
+    service = TestBed.inject(AppHttpApiService);
+    httpHandlers = TestBed.inject(AppHttpHandlersService);
+    httpHandlersSpy = {
+      getEndpoint: jest.spyOn(httpHandlers, 'getEndpoint'),
+      pipeHttpResponse: jest.spyOn(httpHandlers, 'pipeHttpResponse'),
+    };
+    httpClient = TestBed.inject(HttpClient);
+    httpClientGetSpy = jest.spyOn(httpClient, 'get');
+  });
 
   afterEach(() => {
     flushHttpRequests(httpController, true);
   });
 
-  it('the ping method should work as expected', waitForAsync(() => {
-    void service
-      .ping()
-      .pipe(
-        tap(() => {
-          expect(httpHandlersSpy.getEndpoint).toHaveBeenCalledWith('auth');
-          expect(httpClientGetSpy).toHaveBeenCalledWith('http://auth');
-          expect(httpHandlersSpy.pipeHttpResponse).toHaveBeenCalledTimes(1);
-        }),
-      )
-      .subscribe();
-  }));
+  it('the ping method should work as expected', async () => {
+    await lastValueFrom(service.ping());
+    expect(httpHandlersSpy.getEndpoint).toHaveBeenCalledWith('auth');
+    expect(httpClientGetSpy).toHaveBeenCalledWith('http://auth');
+    expect(httpHandlersSpy.pipeHttpResponse).toHaveBeenCalledTimes(1);
+  });
 });

--- a/libs/client-store-http-progress/src/lib/components/global-progress-bar/global-progress-bar.component.spec.ts
+++ b/libs/client-store-http-progress/src/lib/components/global-progress-bar/global-progress-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 import { AppGlobalProgressBarComponent } from './global-progress-bar.component';
@@ -12,15 +12,12 @@ describe('AppGlobalProgressBarComponent', () => {
   let fixture: ComponentFixture<AppGlobalProgressBarComponent>;
   let component: AppGlobalProgressBarComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppGlobalProgressBarComponent);
-        component = fixture.debugElement.componentInstance;
-        fixture.detectChanges();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppGlobalProgressBarComponent);
+    component = fixture.debugElement.componentInstance;
+    fixture.detectChanges();
+  });
 
   it('should be defined', () => {
     expect(component).toBeDefined();

--- a/libs/client-store-http-progress/src/lib/http-progress.effects.spec.ts
+++ b/libs/client-store-http-progress/src/lib/http-progress.effects.spec.ts
@@ -41,15 +41,12 @@ describe('AppHttpProgressEffects', () => {
   let progressService: AppHttpProgressService;
   let toasterService: AppToasterService;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        progressService = TestBed.inject(AppHttpProgressService);
-        toasterService = TestBed.inject(AppToasterService);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    progressService = TestBed.inject(AppHttpProgressService);
+    toasterService = TestBed.inject(AppToasterService);
+  });
 
   it('should call global progress hander start when the start action is dispatched with payload { mainView: true }', waitForAsync(() => {
     store.dispatch(httpProgressActions.start({ payload: { mainView: true } }));

--- a/libs/client-store-http-progress/src/lib/http-progress.reducer.spec.ts
+++ b/libs/client-store-http-progress/src/lib/http-progress.reducer.spec.ts
@@ -18,14 +18,11 @@ describe('AppHttpProgressReducer', () => {
   let reducer: AppHttpProgressReducer;
   let store: Store<IHttpProgressState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppHttpProgressReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppHttpProgressReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();

--- a/libs/client-store-http-progress/src/lib/services/http-handlers/http-handlers.service.spec.ts
+++ b/libs/client-store-http-progress/src/lib/services/http-handlers/http-handlers.service.spec.ts
@@ -41,31 +41,28 @@ describe('AppHttpHandlersService', () => {
   let router: Router;
   let routerNavigateSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppHttpHandlersService);
-        serviceSpies = {
-          checkErrorStatusAndRedirect: jest.spyOn(service, 'checkErrorStatusAndRedirect'),
-          handleGqlError: jest.spyOn(service, 'handleGqlError'),
-          handleError: jest.spyOn(service, 'handleError'),
-        };
-        toaster = TestBed.inject(AppToasterService);
-        httpTestingController = TestBed.inject(HttpTestingController);
-        apollo = TestBed.inject(Apollo);
-        env = TestBed.inject(WEB_CLIENT_APP_ENV);
-        store = TestBed.inject(Store);
-        storeDispatchSpy = jest.spyOn(store, 'dispatch');
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(
-          () =>
-            new Promise<boolean>(resolve => {
-              resolve(true);
-            }),
-        );
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppHttpHandlersService);
+    serviceSpies = {
+      checkErrorStatusAndRedirect: jest.spyOn(service, 'checkErrorStatusAndRedirect'),
+      handleGqlError: jest.spyOn(service, 'handleGqlError'),
+      handleError: jest.spyOn(service, 'handleError'),
+    };
+    toaster = TestBed.inject(AppToasterService);
+    httpTestingController = TestBed.inject(HttpTestingController);
+    apollo = TestBed.inject(Apollo);
+    env = TestBed.inject(WEB_CLIENT_APP_ENV);
+    store = TestBed.inject(Store);
+    storeDispatchSpy = jest.spyOn(store, 'dispatch');
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(
+      () =>
+        new Promise<boolean>(resolve => {
+          resolve(true);
+        }),
+    );
+  });
 
   afterEach(() => {
     flushHttpRequests(httpTestingController, true);

--- a/libs/client-store-http-progress/src/lib/services/http-progress/http-progress.service.spec.ts
+++ b/libs/client-store-http-progress/src/lib/services/http-progress/http-progress.service.spec.ts
@@ -14,14 +14,11 @@ describe('AppHttpProgressService', () => {
   let service: AppHttpProgressService;
   let overlayRef: OverlayRef;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppHttpProgressService);
-        overlayRef = service['progressRef'];
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppHttpProgressService);
+    overlayRef = service['progressRef'];
+  });
 
   it('should be defined', () => {
     expect(service).toBeDefined();

--- a/libs/client-store-http-progress/src/lib/services/toaster/toaster.service.spec.ts
+++ b/libs/client-store-http-progress/src/lib/services/toaster/toaster.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { MatSnackBar, MatSnackBarRef, SimpleSnackBar } from '@angular/material/snack-bar';
 import { TToastType } from '@app/client-util';
 
@@ -29,20 +29,17 @@ describe('AppToasterService', () => {
     };
   };
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppToasterService);
-        snackBar = TestBed.inject(MatSnackBar);
-        spy = {
-          snackBar: {
-            open: jest.spyOn(snackBar, 'open'),
-            dismiss: jest.spyOn(snackBar, 'dismiss'),
-          },
-        };
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppToasterService);
+    snackBar = TestBed.inject(MatSnackBar);
+    spy = {
+      snackBar: {
+        open: jest.spyOn(snackBar, 'open'),
+        dismiss: jest.spyOn(snackBar, 'dismiss'),
+      },
+    };
+  });
 
   afterEach(() => {
     TestBed.resetTestingModule();

--- a/libs/client-store-router/src/lib/router.effects.spec.ts
+++ b/libs/client-store-router/src/lib/router.effects.spec.ts
@@ -29,17 +29,14 @@ describe('AppRouterEffects', () => {
   let routerNavigateSpy: jest.SpyInstance;
   let location: Location;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
-        location = TestBed.inject(Location);
-        (<jest.Mock>location.historyGo).mockClear();
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
+    location = TestBed.inject(Location);
+    (<jest.Mock>location.historyGo).mockClear();
+  });
 
   it('should call router.navigate when the navigate action is dispatched', waitForAsync(() => {
     const payload = { path: [{ outlets: { primary: ['test'] } }] };

--- a/libs/client-store-router/src/lib/router.selectors.spec.ts
+++ b/libs/client-store-router/src/lib/router.selectors.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppTestingComponent, getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
@@ -33,15 +33,12 @@ describe('routerSelectors', () => {
   let store: Store<IRouterState>;
   let router: Router;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        router = TestBed.inject(Router);
-        return router.navigate(['root'], { queryParams: { test: 'test' } });
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+    await router.navigate(['root'], { queryParams: { test: 'test' } });
+  });
 
   it('data', async () => {
     const data = await firstValueFrom(store.select(routerSelectors.data).pipe(first()));

--- a/libs/client-store-sidebar/src/lib/sidebar.effects.spec.ts
+++ b/libs/client-store-sidebar/src/lib/sidebar.effects.spec.ts
@@ -23,15 +23,12 @@ describe('AppSidebarEffects', () => {
   let router: Router;
   let routerNavigateSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
+  });
 
   it('should call router.navigate when the open action is dispatched with payload { navigate: true }', waitForAsync(() => {
     store.dispatch(sidebarActions.open({ payload: { navigate: true } }));

--- a/libs/client-store-sidebar/src/lib/sidebar.reducer.spec.ts
+++ b/libs/client-store-sidebar/src/lib/sidebar.reducer.spec.ts
@@ -1,7 +1,7 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 import { getTestBedConfig, newTestBedMetadata } from '@app/client-testing-unit';
 import { Store, StoreModule } from '@ngrx/store';
-import { first, switchMap, tap } from 'rxjs';
+import { first, lastValueFrom } from 'rxjs';
 
 import { sidebarActions } from './sidebar.actions';
 import { ISidebarState, ISidebarStateModel, sidebarReducerConfig } from './sidebar.interface';
@@ -18,14 +18,11 @@ describe('AppSidebarReducer', () => {
   let reducer: AppSidebarReducer;
   let store: Store<ISidebarState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppSidebarReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppSidebarReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();
@@ -37,52 +34,27 @@ describe('AppSidebarReducer', () => {
     expect(initialState).toEqual(expectation);
   });
 
-  it('should process the open action correctly', waitForAsync(() => {
+  it('should process the open action correctly', async () => {
     store.dispatch(sidebarActions.open({ payload: { navigate: false } }));
-    void store
-      .select(sidebarSelectors.sidebarOpen)
-      .pipe(
-        first(),
-        tap(sidebarOpen => {
-          expect(sidebarOpen).toBeTruthy();
-        }),
-      )
-      .subscribe();
-  }));
+    const sidebarOpen = await lastValueFrom(store.select(sidebarSelectors.sidebarOpen).pipe(first()));
+    expect(sidebarOpen).toBeTruthy();
+  });
 
-  it('should process the close action correctly', waitForAsync(() => {
+  it('should process the close action correctly', async () => {
     store.dispatch(sidebarActions.open({ payload: { navigate: false } }));
-    void store
-      .select(sidebarSelectors.sidebarOpen)
-      .pipe(
-        first(),
-        tap(sidebarOpen => {
-          expect(sidebarOpen).toBeTruthy();
-          store.dispatch(sidebarActions.close({ payload: { navigate: false } }));
-        }),
-        switchMap(() => store.select(sidebarSelectors.sidebarOpen).pipe(first())),
-        tap(sidebarOpen => {
-          expect(sidebarOpen).toBeFalsy();
-        }),
-      )
-      .subscribe();
-  }));
+    let sidebarOpen = await lastValueFrom(store.select(sidebarSelectors.sidebarOpen).pipe(first()));
+    expect(sidebarOpen).toBeTruthy();
+    store.dispatch(sidebarActions.close({ payload: { navigate: false } }));
+    sidebarOpen = await lastValueFrom(store.select(sidebarSelectors.sidebarOpen).pipe(first()));
+    expect(sidebarOpen).toBeFalsy();
+  });
 
-  it('should process the toggle action correctly', waitForAsync(() => {
+  it('should process the toggle action correctly', async () => {
     store.dispatch(sidebarActions.toggle());
-    void store
-      .select(sidebarSelectors.sidebarOpen)
-      .pipe(
-        first(),
-        tap(sidebarOpen => {
-          expect(sidebarOpen).toBeTruthy();
-          store.dispatch(sidebarActions.toggle());
-        }),
-        switchMap(() => store.select(sidebarSelectors.sidebarOpen)),
-        tap(sidebarOpen => {
-          expect(sidebarOpen).toBeFalsy();
-        }),
-      )
-      .subscribe();
-  }));
+    let sidebarOpen = await lastValueFrom(store.select(sidebarSelectors.sidebarOpen).pipe(first()));
+    expect(sidebarOpen).toBeTruthy();
+    store.dispatch(sidebarActions.toggle());
+    sidebarOpen = await lastValueFrom(store.select(sidebarSelectors.sidebarOpen).pipe(first()));
+    expect(sidebarOpen).toBeFalsy();
+  });
 });

--- a/libs/client-store-theme/src/lib/theme.effects.spec.ts
+++ b/libs/client-store-theme/src/lib/theme.effects.spec.ts
@@ -22,14 +22,11 @@ describe('AppThemeEffects', () => {
   let store: Store<IThemeState>;
   let overlay: OverlayContainer;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        overlay = TestBed.inject(OverlayContainer);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    overlay = TestBed.inject(OverlayContainer);
+  });
 
   it('should add "unicorn-dark-theme" class to the overlay container when the enableDarkTheme action is dispatched', waitForAsync(() => {
     const addSpy = jest.spyOn(overlay.getContainerElement().classList, 'add');

--- a/libs/client-store-theme/src/lib/theme.reducer.spec.ts
+++ b/libs/client-store-theme/src/lib/theme.reducer.spec.ts
@@ -18,14 +18,11 @@ describe('AppThemeReducer', () => {
   let reducer: AppThemeReducer;
   let store: Store<IThemeState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppThemeReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppThemeReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();

--- a/libs/client-store-user/src/lib/user.effects.spec.ts
+++ b/libs/client-store-user/src/lib/user.effects.spec.ts
@@ -23,15 +23,12 @@ describe('AppUserEffects', () => {
   let router: Router;
   let routerNavigateSpy: jest.SpyInstance;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        store = TestBed.inject(Store);
-        router = TestBed.inject(Router);
-        routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    store = TestBed.inject(Store);
+    router = TestBed.inject(Router);
+    routerNavigateSpy = jest.spyOn(router, 'navigate').mockImplementation(() => new Promise<boolean>(resolve => resolve(true)));
+  });
 
   it('should call router.navigate when the login action is dispatched', waitForAsync(() => {
     store.dispatch(userActions.login({ payload: { email: 'test@test.test' } }));

--- a/libs/client-store-user/src/lib/user.reducer.spec.ts
+++ b/libs/client-store-user/src/lib/user.reducer.spec.ts
@@ -18,14 +18,11 @@ describe('AppUserReducer', () => {
   let reducer: AppUserReducer;
   let store: Store<IUserState>;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        reducer = TestBed.inject(AppUserReducer);
-        store = TestBed.inject(Store);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    reducer = TestBed.inject(AppUserReducer);
+    store = TestBed.inject(Store);
+  });
 
   it('should be defined', () => {
     expect(reducer).toBeDefined();

--- a/libs/client-store/src/lib/store.module.spec.ts
+++ b/libs/client-store/src/lib/store.module.spec.ts
@@ -1,13 +1,11 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { AppStoreModule } from './store.module';
 
 describe('AppStoreModule', () => {
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
-      imports: [AppStoreModule],
-    }).compileComponents();
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [AppStoreModule] }).compileComponents();
+  });
 
   it('should be defined', () => {
     expect(AppStoreModule).toBeDefined();

--- a/libs/client-translate/src/lib/dictionaries/en.spec.ts
+++ b/libs/client-translate/src/lib/dictionaries/en.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { IUiDictionary } from '../interfaces';
 import { EN, EN_DICTIONARY } from './en';
@@ -6,20 +6,17 @@ import { EN, EN_DICTIONARY } from './en';
 describe('English shared translations', () => {
   let dictionary: IUiDictionary;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       providers: [
         {
           provide: EN_DICTIONARY,
           useValue: EN,
         },
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        dictionary = TestBed.inject(EN_DICTIONARY);
-      });
-  }));
+    }).compileComponents();
+    dictionary = TestBed.inject(EN_DICTIONARY);
+  });
 
   it('should create the app', () => {
     expect(dictionary).toEqual(

--- a/libs/client-translate/src/lib/dictionaries/ru.spec.ts
+++ b/libs/client-translate/src/lib/dictionaries/ru.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 
 import { IUiDictionary } from '../interfaces';
 import { RU, RU_DICTIONARY } from './ru';
@@ -6,20 +6,17 @@ import { RU, RU_DICTIONARY } from './ru';
 describe('Russian shared translations', () => {
   let dictionary: IUiDictionary;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       providers: [
         {
           provide: RU_DICTIONARY,
           useValue: RU,
         },
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        dictionary = TestBed.inject(RU_DICTIONARY);
-      });
-  }));
+    }).compileComponents();
+    dictionary = TestBed.inject(RU_DICTIONARY);
+  });
 
   it('should create the app', () => {
     expect(dictionary).toEqual(

--- a/libs/client-translate/src/lib/services/app-translation-utils.service.spec.ts
+++ b/libs/client-translate/src/lib/services/app-translation-utils.service.spec.ts
@@ -32,31 +32,27 @@ describe('AppTranslationUtilsService', () => {
     };
   };
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppTranslationUtilsService);
-        translate = TestBed.inject(TranslateService);
-        dateAdapter = TestBed.inject(DateAdapter);
-        win = TestBed.inject(WINDOW);
-
-        spy = {
-          service: {
-            languageChanges: jest.spyOn((service as any).languageChangesSubject, 'next'),
-          },
-          translate: {
-            onLangChange: jest.spyOn(translate.onLangChange, 'subscribe'),
-            setDefaultLang: jest.spyOn(translate, 'setDefaultLang'),
-            setTranslation: jest.spyOn(translate, 'setTranslation'),
-            use: jest.spyOn(translate, 'use'),
-          },
-          dateAdapter: {
-            setLocale: jest.spyOn(dateAdapter, 'setLocale'),
-          },
-        };
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    service = TestBed.inject(AppTranslationUtilsService);
+    translate = TestBed.inject(TranslateService);
+    dateAdapter = TestBed.inject(DateAdapter);
+    win = TestBed.inject(WINDOW);
+    spy = {
+      service: {
+        languageChanges: jest.spyOn((service as any).languageChangesSubject, 'next'),
+      },
+      translate: {
+        onLangChange: jest.spyOn(translate.onLangChange, 'subscribe'),
+        setDefaultLang: jest.spyOn(translate, 'setDefaultLang'),
+        setTranslation: jest.spyOn(translate, 'setTranslation'),
+        use: jest.spyOn(translate, 'use'),
+      },
+      dateAdapter: {
+        setLocale: jest.spyOn(dateAdapter, 'setLocale'),
+      },
+    };
+  });
 
   it('should exist and have variables and methods defined', () => {
     expect(service).toBeDefined();

--- a/libs/client-util-sentry/src/lib/services/sentry/sentry.service.spec.ts
+++ b/libs/client-util-sentry/src/lib/services/sentry/sentry.service.spec.ts
@@ -1,5 +1,5 @@
 import { FactoryProvider } from '@angular/core';
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { testingEnvironment } from '@app/client-testing-unit';
 import * as Sentry from '@sentry/angular-ivy';
 
@@ -8,8 +8,8 @@ import { AppSentryService, initializeSentry, sentryProviders } from './sentry.se
 describe('AppSentryService', () => {
   let service: AppSentryService;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       providers: [
         {
           provide: Sentry.TraceService,
@@ -21,12 +21,9 @@ describe('AppSentryService', () => {
           deps: [Sentry.TraceService],
         },
       ],
-    })
-      .compileComponents()
-      .then(() => {
-        service = TestBed.inject(AppSentryService);
-      });
-  }));
+    }).compileComponents();
+    service = TestBed.inject(AppSentryService);
+  });
 
   it('should exist', () => {
     expect(service).toBeTruthy();

--- a/libs/client-util/src/lib/decorators/track-changes.decorator.spec.ts
+++ b/libs/client-util/src/lib/decorators/track-changes.decorator.spec.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChange, SimpleChanges } from '@angular/core';
-import { ComponentFixture, TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { trackChanges } from './track-changes.decorator';
 
@@ -38,14 +38,11 @@ describe('trackChanges', () => {
   let fixture: ComponentFixture<AppTrackChangesTestingComponent>;
   let component: AppTrackChangesTestingComponent;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        fixture = TestBed.createComponent(AppTrackChangesTestingComponent);
-        component = fixture.componentInstance;
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    fixture = TestBed.createComponent(AppTrackChangesTestingComponent);
+    component = fixture.componentInstance;
+  });
 
   it('should process changes as expected when the input value change is defined', () => {
     expect(component.input).toBeUndefined();

--- a/libs/client-util/src/lib/providers/app-base-href.provider.spec.ts
+++ b/libs/client-util/src/lib/providers/app-base-href.provider.spec.ts
@@ -1,5 +1,5 @@
 import { APP_BASE_HREF } from '@angular/common';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { appBaseHrefProvider } from './app-base-href.provider';
 
@@ -10,13 +10,10 @@ describe('appBaseHrefProvider', () => {
 
   let provider: string;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        provider = TestBed.inject(APP_BASE_HREF);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    provider = TestBed.inject(APP_BASE_HREF);
+  });
 
   it('should be defined', () => {
     expect(provider).toEqual('/');

--- a/libs/client-util/src/lib/providers/document.provider.spec.ts
+++ b/libs/client-util/src/lib/providers/document.provider.spec.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { documentProvider } from './document.provider';
 
@@ -10,13 +10,10 @@ describe('documentProvider', () => {
 
   let provider: Document;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        provider = TestBed.inject(DOCUMENT);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    provider = TestBed.inject(DOCUMENT);
+  });
 
   it('should be defined', () => {
     expect(provider).toBeDefined();

--- a/libs/client-util/src/lib/providers/environment.provider.spec.ts
+++ b/libs/client-util/src/lib/providers/environment.provider.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { IWebClientAppEnvironment } from '../interfaces/environment.interface';
 import { environmentProvider, WEB_CLIENT_APP_ENV } from './environment.provider';
@@ -28,13 +28,10 @@ describe('environmentProvider', () => {
 
   let provider: IWebClientAppEnvironment;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        provider = TestBed.inject(WEB_CLIENT_APP_ENV);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    provider = TestBed.inject(WEB_CLIENT_APP_ENV);
+  });
 
   it('should be defined', () => {
     expect(provider).toBeDefined();

--- a/libs/client-util/src/lib/providers/location-strategy.provider.spec.ts
+++ b/libs/client-util/src/lib/providers/location-strategy.provider.spec.ts
@@ -1,5 +1,5 @@
 import { LocationStrategy, PathLocationStrategy } from '@angular/common';
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { appBaseHrefProvider } from './app-base-href.provider';
 import { pathLocationStrategyProvider } from './location-strategy.provider';
@@ -11,13 +11,10 @@ describe('pathLocationStrategyProvider', () => {
 
   let provider: LocationStrategy;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        provider = TestBed.inject(LocationStrategy);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    provider = TestBed.inject(LocationStrategy);
+  });
 
   it('should be defined', () => {
     expect(provider instanceof PathLocationStrategy).toBeTruthy();

--- a/libs/client-util/src/lib/providers/window.provider.spec.ts
+++ b/libs/client-util/src/lib/providers/window.provider.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, TestModuleMetadata, waitForAsync } from '@angular/core/testing';
+import { TestBed, TestModuleMetadata } from '@angular/core/testing';
 
 import { WINDOW, windowProvider } from './window.provider';
 
@@ -9,13 +9,10 @@ describe('windowProvider', () => {
 
   let provider: Window;
 
-  beforeEach(waitForAsync(() => {
-    void TestBed.configureTestingModule(testBedConfig)
-      .compileComponents()
-      .then(() => {
-        provider = TestBed.inject(WINDOW);
-      });
-  }));
+  beforeEach(async () => {
+    await TestBed.configureTestingModule(testBedConfig).compileComponents();
+    provider = TestBed.inject(WINDOW);
+  });
 
   it('should be defined', () => {
     expect(provider).toBeDefined();


### PR DESCRIPTION
- [x] use native async instead of the helper that creates an async wrapper;